### PR TITLE
Graphics: Fix transparent pixel on 1x road barriers

### DIFF
--- a/graphics/infrastructure/64/road_oneway_32bpp.pdn
+++ b/graphics/infrastructure/64/road_oneway_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d31f1eac6c8b55ec6f91ea5dd3e062b691689515304b3bbab4f5ec5bc9fd95ee
-size 31212
+oid sha256:e389fab0cd980c7a1db89d2ad8f8058bdb93572957cf70e79b25b5f29c723491
+size 31193

--- a/graphics/infrastructure/64/road_oneway_32bpp.png
+++ b/graphics/infrastructure/64/road_oneway_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbd868b46224f002dceeb0945b0bd22d9c43bf409fd0f3f7250d697909446741
-size 3928
+oid sha256:45e80075b978a125c604ee9511d24d21746094df73d29b9aec055a3711ec927c
+size 1415


### PR DESCRIPTION
On some of the barrier sprites there was a transparent pixel that appeared dark-blue in-game.