### PR TITLE
Codechange: Version bumps and documentation for v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenGFX2 Changelog
 
+## v0.8.1
+Base sets:
+* Fix internal baseset version (#223)
+
 ## v0.8
 Base set:
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # Version reported to users
-USER_VERSION := 0.8
+USER_VERSION := 0.8.1
 
 # Always run version detection, so we always have an accurate modified flag
 REPO_VERSIONS := $(shell AWK="$(AWK)" "./findversion.sh")


### PR DESCRIPTION
Update changelog and bump versions in preparation for v0.8.1 release.

[Fresh build internal baseset/newgrf version comes out as 9480, much greater than the (accidental) version 7 for v8.0, so should solve all version issues.]