### PR TITLE
Fix: Incorrect grass shading for 4x zoom arctic snow transition

### DIFF
--- a/graphics/terrain/256/arctic_groundtiles_snowtransition_32bpp.pdn
+++ b/graphics/terrain/256/arctic_groundtiles_snowtransition_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba4962545aaf062ef421c9203c4a50b56e05b40010be1968bd5530c1b4382a9c
-size 16277492
+oid sha256:b0cd396617b54c972d92b2a4a77f416fee20b1bd6b59d5fd438febf25224010b
+size 15478403

--- a/graphics/terrain/256/arctic_groundtiles_snowtransition_32bpp.png
+++ b/graphics/terrain/256/arctic_groundtiles_snowtransition_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12212decf1c198172f941ebbc71641e613abbced97d14bf7ba3ab98fdad1f518
-size 2150631
+oid sha256:2510091f3dca7963fc61dbd5f546e3d36783d263edc5dc173d2588b7010f555e
+size 1917712


### PR DESCRIPTION
The arctic (and only the arctic, and only at 4x zoom) snow transition slopes had an extra graphics layer to shade the grass. That layer isn't present for the non-snowy grass or for temperate/tropical-style grass snow transitions. This led to mismatched shading with non-snowy grass. Remove the layer from the source `pdn` and make a new `png` to fix the issue.

<img width="797" height="607" alt="image" src="https://github.com/user-attachments/assets/3b5c02b9-a703-4939-a23c-bbee5be36488" />

Fixes #224