### PR TITLE
Fix: Make sea level locks aware of neighbouring canals

### DIFF
--- a/baseset/nml/extra/extra-plus-locks.pnml
+++ b/baseset/nml/extra/extra-plus-locks.pnml
@@ -6,9 +6,17 @@ spriteset (waterfeature_locks_general, "../graphics/stations/general/64/pygen/do
 spriteset (waterfeature_locks_arctic_snow, "../graphics/stations/general/64/pygen/docksandlocks_snow_8bpp.png") { template_locks(0, 0, 1) } //snowy
 #32 alternative_sprites(waterfeature_locks_arctic_snow, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/stations/general/64/pygen/docksandlocks_snow_rm32bpp.png", "../graphics/stations/general/64/pygen/docksandlocks_snow_8bpp.png") { template_locks(0, 0, 1) }
 
+// switch for canal banks (for better behaviour when neighbouring sea-level canals)
+switch (FEAT_CANALS, SELF, switch_waterfeature_locks_banks,
+	getbits(dike_map,0,1) || getbits(dike_map,1,1) || getbits(dike_map,2,1) || getbits(dike_map,3,1)
+) {
+	1: waterfeature_locks_general;
+	waterfeature_locks_sealevel;
+}
+
 // switch for elevation
 switch (FEAT_CANALS, SELF, switch_waterfeature_locks_elevation, tile_height) {
-	0: waterfeature_locks_sealevel;
+	0: switch_waterfeature_locks_banks;
 	waterfeature_locks_general;
 }
 


### PR DESCRIPTION
Canal locks checked for elevation, to use alternate graphics with mini-lighthouses and breaking waves when at sea level. This looked odd when building locks on sea level land.

Therefore, add a `canal_dike` check, to check if canal walls would be built for that tile as a half-decent proxy for checking for neighbouring land tiles. Compare the top two locks in the example image.
<img width="1035" height="575" alt="image" src="https://github.com/user-attachments/assets/66ec0ff1-5e5c-4021-8921-8775f5380ae0" />

(mostly) Fixes #237

Corner cases are when the lock is surrounded by sea level locks or rivers. Com[are the bottom two locks in the example image.