### PR TITLE
Fix: Swapped handling of high bit depth and extra zoom in nml preprocessing

### DIFF
--- a/templates/nml_preprocessor.py
+++ b/templates/nml_preprocessor.py
@@ -109,7 +109,7 @@ def preprocess_pnml(pnml_path, newgrf_version, high_bitdepth = False, extra_zoom
     # define alternate comment strings
     comment_alternate = ["#ez ", "#32 "]
 
-    settings_alternate = [high_bitdepth, extra_zoom]
+    settings_alternate = [extra_zoom, high_bitdepth]
     for c in range(len(comment_alternate)):
       comment = comment_alternate[c]
       if comment in line:


### PR DESCRIPTION
The `grf` build pipeline uses preprocessing of `nml` files to remove or retain lines marked with combinations of `#32` and `#ez` as requested, to make `nml` variants which include 32bpp and 4x extra zoom sprites when wanted.

The preprocessor was retaining 32bpp images when 4x zoom was requested, and 4x zoom when 32bpp images were requested. Not a problem for building the current variants (1x 8bpp Classic, 4x 32bpp High Def) because it was 'all or nothing', but caused the `nml` for the wrong variant to be generated if 1x 32bpp or 4x 8bpp was requested.