### PR TITLE
Update: signals depend on signal side

### DIFF
--- a/baseset/nml/extra/extra-signals.pnml
+++ b/baseset/nml/extra/extra-signals.pnml
@@ -39,7 +39,7 @@ replacenew presignalsemaphorepbs_208(PRE_SIGNAL_SEMAPHORE_PBS, "../graphics/sign
 replacenew presignalsemaphorepbs_224(PRE_SIGNAL_SEMAPHORE_PBS, "../graphics/signals/64/pbs_semaphore_leftside_unusedalt_8bpp.png", 224) { template_signals_base_empty() } //unused
 
 //German-style for TRAFFIC_SIDE_RIGHT
-if ((traffic_side == TRAFFIC_SIDE_RIGHT)) {
+if ((traffic_side == TRAFFIC_SIDE_RIGHT) == signals_on_traffic_side) {
 	replacenew presignalsemaphorepbs_48_rightside(PRE_SIGNAL_SEMAPHORE_PBS, "../graphics/signals/64/base_semaphore_rightside_8bpp.png", 48) { template_signals_base(1, 0) } //base/block
 	#ez alternative_sprites(presignalsemaphorepbs_48_rightside, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/signals/256/base_semaphore_rightside_8bpp.png") { template_signals_base(4, 0) }
 	replacenew presignalsemaphorepbs_64_rightside(PRE_SIGNAL_SEMAPHORE_PBS, "../graphics/signals/64/presignal_semaphore_rightside_entry_8bpp.png", 64) { template_signals_base(1, 0) } //pre-signal, entry


### PR DESCRIPTION
This depends on https://github.com/OpenTTD/OpenTTD/pull/15661

This now takes _signal side_ (interface setting) into consideration, rather relying solely on _driving side_ setting.

See also https://github.com/OpenTTD/OpenTTD/issues/15608