### PR TITLE
Fix: Use specific cursor for ship depots

### DIFF
--- a/baseset/nml/base/base-0674-gui.pnml
+++ b/baseset/nml/base/base-0674-gui.pnml
@@ -110,7 +110,7 @@ base_graphics spr716( 716, "../graphics/cursors/1/pygen/default_8bpp.png") {
     template_cursor_matrix(2, 4, 1) // vehicle orders: 3/3
     template_cursor_matrix(0, 1, 1) // cursor: land area information
     template_cursor_matrix(1, 1, 1) // cursor: build hq
-    template_cursor_matrix(0, 6, 1) // cursor: build depot
+    template_cursor_matrix(0, 13, 1) // cursor: build ship depot
     template_cursor_matrix(2, 1, 1) // cursor: place sign
 }
 //723-746 toolbar icons

--- a/baseset/nml/extra/extra-param-cursors.pnml
+++ b/baseset/nml/extra/extra-param-cursors.pnml
@@ -23,7 +23,7 @@ template template_spr716(z) {
     template_cursor_matrix(2, 4, z) // vehicle orders: 3/3
     template_cursor_matrix(0, 1, z) // cursor: land area information
     template_cursor_matrix(1, 1, z) // cursor: build hq
-    template_cursor_matrix(0, 6, z) // cursor: build depot
+    template_cursor_matrix(0, 13, z) // cursor: build ship depot
     template_cursor_matrix(2, 1, z) // cursor: place sign
 }
 template template_spr1263(z) {

--- a/graphics/cursors/cursoroverlay.py
+++ b/graphics/cursors/cursoroverlay.py
@@ -115,6 +115,7 @@ def cursors_cursoroverlay(base_path, scale, verbose=True):
     {"sx": 6, "sy": 21, "tx": 10, "ty": 10}, # ship clone
     {"sx": 7, "sy": 21, "tx": 10, "ty": 11}, # aircraft clone
     {"sx": 3.5, "sy": 7, "tx": 0, "ty": 12}, # airport
+    {"sx": 2, "sy": 8, "tx": 0, "ty": 13}, # waterway depot
     {"sx": 3, "sy": 8, "tx": 1, "ty": 13}, # waterway lock
     {"sx": 7, "sy": 8, "tx": 2, "ty": 13}, # waterway canal
     {"sx": 4, "sy": 15, "tx": 3, "ty": 13}, # waterway river


### PR DESCRIPTION
Sprite 721 was treated as a general depot cursor, but should have been the water/ship-specific one.

<img width="883" height="552" alt="image" src="https://github.com/user-attachments/assets/b88dd76c-dfb6-4961-9082-9b36fb86abc9" />
